### PR TITLE
Move outputDir config attribute to cmd flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ make build
   Usage of ./meme-as-code:
     -config-file string
           The path to the config file. (default "config.yaml")
+    -output-dir string
+          The path where to download memes. (default "output")
     -override
           Override existing files.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	configPath = flag.String("config-file", "config.yaml", "The path to the config file.")
+	outputDir  = flag.String("output-dir", "output", "The path where to download memes.")
 	override   = flag.Bool("override", false, "Override existing files.")
 )
 
@@ -26,6 +27,7 @@ func main() {
 	if config.Username == "" || config.Password == "" {
 		log.Fatal("Please, provide a valid username and password from environment variables USER and PASS")
 	}
+	config.OutputDir = *outputDir
 	config.Overrive = *override
 	err = GetMemes(config)
 	if err != nil {

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,3 @@
-output_dir: output
 memes:
   - filename: one-just-dont-simply-01.jpg
     template_id: "61579"

--- a/src/config.go
+++ b/src/config.go
@@ -13,7 +13,7 @@ type Meme struct {
 }
 
 type Config struct {
-	OutputDir string `yaml:"output_dir"`
+	OutputDir string `default:""`
 	Username  string `default:""`
 	Password  string `default:""`
 	Overrive  bool   `default:false`

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Config", func() {
 			Expect(err).To(BeNil())
 
 			expected := &Config{
-				OutputDir: "output",
+				OutputDir: "",
 				Username:  "",
 				Password:  "",
 				Overrive:  false,

--- a/src/test-artifacts/config.yaml
+++ b/src/test-artifacts/config.yaml
@@ -1,4 +1,3 @@
-output_dir: output
 memes:
   - filename: one-just-dont-simply-01.jpg
     template_id: "61579"


### PR DESCRIPTION
Hola!

I want to address the #1 issue.

What I do here is following what you did with the `--override` flag; getting its value from `flags` to override the default value in the `Config` struct instance.

I've set the `---output-dir` default value to `output`, which was the same value defined in the `config.yaml` file.

Let me know if everything is fine!