### PR TITLE
chore: fix var spelling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,7 +28,7 @@ func main() {
 		log.Fatal("Please, provide a valid username and password from environment variables USER and PASS")
 	}
 	config.OutputDir = *outputDir
-	config.Overrive = *override
+	config.Override = *override
 	err = GetMemes(config)
 	if err != nil {
 		log.Fatal(err)

--- a/src/config.go
+++ b/src/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	OutputDir string `default:""`
 	Username  string `default:""`
 	Password  string `default:""`
-	Overrive  bool   `default:false`
+	Override  bool   `default:false`
 	Memes     []Meme `yaml:"memes"`
 }
 

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Config", func() {
 				OutputDir: "",
 				Username:  "",
 				Password:  "",
-				Overrive:  false,
+				Override:  false,
 				Memes: []Meme{
 					{
 						Filename:   "one-just-dont-simply-01.jpg",

--- a/src/imgflip_api.go
+++ b/src/imgflip_api.go
@@ -26,7 +26,7 @@ func GetMemes(config *Config) error {
 		}
 		err = downloadFile(imageUrl,
 			config.OutputDir+"/"+meme.Filename,
-			config.Overrive)
+			config.Override)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Hey David!

There was a typo in a var name. This PR fixes just that. Funny tool!